### PR TITLE
feat: Add alias management (merged from zam)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -342,6 +342,69 @@ pub struct SessionsArgs {
     pub detailed: bool,
 }
 
+#[derive(Args)]
+pub struct AliasArgs {
+    #[command(subcommand)]
+    pub command: AliasCommands,
+}
+
+#[derive(clap::Subcommand)]
+pub enum AliasCommands {
+    /// Add a new alias
+    Add(AliasAddArgs),
+    /// Update an existing alias
+    Update(AliasUpdateArgs),
+    /// Remove an alias
+    Remove(AliasRemoveArgs),
+    /// List all aliases
+    List(AliasListArgs),
+    /// Export aliases as a shell script
+    Export(AliasExportArgs),
+    /// Sync aliases from shell (reads alias output from stdin)
+    Sync,
+}
+
+#[derive(Args)]
+pub struct AliasAddArgs {
+    /// Alias name
+    pub name: String,
+    /// Command the alias expands to
+    pub command: String,
+    /// Description of the alias
+    pub description: String,
+}
+
+#[derive(Args)]
+pub struct AliasUpdateArgs {
+    /// Alias name
+    pub name: String,
+    /// New command the alias expands to
+    pub command: String,
+    /// New description (optional)
+    #[arg(short, long)]
+    pub description: Option<String>,
+}
+
+#[derive(Args)]
+pub struct AliasRemoveArgs {
+    /// Alias name to remove
+    pub name: String,
+}
+
+#[derive(Args)]
+pub struct AliasListArgs {
+    /// Output in shell eval-ready format (alias name='cmd')
+    #[arg(long)]
+    pub shell: bool,
+}
+
+#[derive(Args)]
+pub struct AliasExportArgs {
+    /// Output file (stdout if not specified)
+    #[arg(short = 'O', long)]
+    pub output: Option<std::path::PathBuf>,
+}
+
 #[derive(clap::ValueEnum, Clone)]
 pub enum ShellType {
     Zsh,

--- a/src/cli/handlers/alias.rs
+++ b/src/cli/handlers/alias.rs
@@ -1,0 +1,155 @@
+//! Alias management handlers for Mortimer CLI
+
+use crate::cli::args::*;
+use crate::cli::{CliApp, HistoryBackend};
+use crate::error::{Error, Result};
+use std::io::{self, BufRead};
+
+pub fn handle_alias(app: &mut CliApp, args: &AliasArgs) -> Result<()> {
+    let db = match &app.backend {
+        HistoryBackend::Database(mgr) => &mgr.db,
+        HistoryBackend::File(_) => {
+            return Err(Error::custom(
+                "Alias management requires the database backend. Use --use-db flag.",
+            ));
+        }
+    };
+
+    match &args.command {
+        AliasCommands::Add(add_args) => {
+            db.add_alias(&add_args.name, &add_args.command, &add_args.description)?;
+            if !app.quiet {
+                println!("Alias '{}' added successfully", add_args.name);
+            }
+        }
+        AliasCommands::Update(update_args) => {
+            db.update_alias(
+                &update_args.name,
+                &update_args.command,
+                update_args.description.as_deref(),
+            )?;
+            if !app.quiet {
+                println!("Alias '{}' updated successfully", update_args.name);
+            }
+        }
+        AliasCommands::Remove(remove_args) => {
+            db.remove_alias(&remove_args.name)?;
+            if !app.quiet {
+                println!("Alias '{}' removed successfully", remove_args.name);
+            }
+        }
+        AliasCommands::List(list_args) => {
+            let aliases = db.list_aliases()?;
+
+            if list_args.shell {
+                for a in &aliases {
+                    println!("alias {}='{}'", a.alias, a.command.replace('\'', "'\\''"));
+                }
+            } else if aliases.is_empty() {
+                println!("No aliases found.");
+            } else {
+                // Calculate column widths
+                let name_width = aliases.iter().map(|a| a.alias.len()).max().unwrap_or(5).max(5);
+                let cmd_width = aliases
+                    .iter()
+                    .map(|a| a.command.len())
+                    .max()
+                    .unwrap_or(7)
+                    .clamp(7, 60);
+
+                let desc_header = "DESCRIPTION";
+                println!(
+                    "{:<name_width$}  {:<cmd_width$}  {desc_header}",
+                    "ALIAS", "COMMAND"
+                );
+                println!(
+                    "{:<name_width$}  {:<cmd_width$}  {}",
+                    "-".repeat(name_width),
+                    "-".repeat(cmd_width),
+                    "-".repeat(20)
+                );
+
+                for a in &aliases {
+                    let cmd_display = if a.command.len() > 60 {
+                        format!("{}...", &a.command[..57])
+                    } else {
+                        a.command.clone()
+                    };
+                    println!(
+                        "{:<name_width$}  {:<cmd_width$}  {}",
+                        a.alias, cmd_display, a.description
+                    );
+                }
+            }
+        }
+        AliasCommands::Export(export_args) => {
+            let aliases = db.list_aliases()?;
+            let mut output = String::from("#!/bin/sh\n# Aliases exported by mortimer\n\n");
+
+            for a in &aliases {
+                output.push_str(&format!(
+                    "alias {}='{}'\n",
+                    a.alias,
+                    a.command.replace('\'', "'\\''")
+                ));
+            }
+
+            if let Some(path) = &export_args.output {
+                std::fs::write(path, &output)?;
+                if !app.quiet {
+                    println!("Aliases exported to {}", path.display());
+                }
+            } else {
+                print!("{}", output);
+            }
+        }
+        AliasCommands::Sync => {
+            let aliases = parse_alias_lines_from_stdin()?;
+            let count = db.sync_aliases(&aliases)?;
+            if !app.quiet {
+                println!("Synced {} aliases", count);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse alias definitions from stdin (output of shell `alias` builtin)
+/// Handles formats:
+///   - zsh/bash: `name='command'` or `name=command`
+///   - also handles: `alias name='command'`
+fn parse_alias_lines_from_stdin() -> Result<Vec<(String, String)>> {
+    let stdin = io::stdin();
+    let mut aliases = Vec::new();
+
+    for line in stdin.lock().lines() {
+        let line = line.map_err(|e| Error::custom(format!("Failed to read stdin: {}", e)))?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Strip leading "alias " if present
+        let line = line.strip_prefix("alias ").unwrap_or(line);
+
+        // Split on first '='
+        if let Some(eq_pos) = line.find('=') {
+            let name = line[..eq_pos].trim().to_string();
+            let mut value = line[eq_pos + 1..].trim().to_string();
+
+            // Strip surrounding quotes
+            if (value.starts_with('\'') && value.ends_with('\''))
+                || (value.starts_with('"') && value.ends_with('"'))
+            {
+                value = value[1..value.len() - 1].to_string();
+            }
+
+            if !name.is_empty() && !value.is_empty() {
+                aliases.push((name, value));
+            }
+        }
+    }
+
+    Ok(aliases)
+}

--- a/src/cli/handlers/mod.rs
+++ b/src/cli/handlers/mod.rs
@@ -7,6 +7,7 @@
 //! - `config`: Configuration and shell integration handlers
 //! - `util`: Utility functions for handlers
 
+mod alias;
 mod basic;
 mod config;
 mod database;
@@ -14,6 +15,7 @@ mod import_export;
 mod manage;
 mod shell_integration;
 
+pub use alias::*;
 pub use basic::*;
 pub use config::*;
 pub use database::*;

--- a/src/cli/handlers/shell_integration.rs
+++ b/src/cli/handlers/shell_integration.rs
@@ -46,6 +46,9 @@ zle -N mortimer-fzf-widget
 
 # Replace default Ctrl-R with fzf search
 bindkey '^R' mortimer-fzf-widget
+
+# Sync current shell aliases to mortimer on startup
+alias | mortimer alias sync &>/dev/null &
 "#
     .to_string()
 }
@@ -64,6 +67,9 @@ PROMPT_COMMAND="log_command \"\$BASH_COMMAND\"; $PROMPT_COMMAND"
 
 # Interactive history search with fzf (Ctrl+R)
 bind -x '"\C-r": "READLINE_LINE=$(mortimer fzf | fzf --height 50% --reverse --tac 2>/dev/tty); READLINE_POINT=${#READLINE_LINE}"'
+
+# Sync current shell aliases to mortimer on startup
+alias | mortimer alias sync &>/dev/null &
 "#
     .to_string()
 }
@@ -88,6 +94,9 @@ end
 
 # Replace default Ctrl-R with fzf search
 bind \cr mortimer_fzf_search
+
+# Sync current shell aliases to mortimer on startup
+alias | mortimer alias sync &>/dev/null &
 "#
     .to_string()
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -94,6 +94,8 @@ pub enum Commands {
     Hosts(HostsArgs),
     /// List and manage sessions
     Sessions(SessionsArgs),
+    /// Manage shell aliases
+    Alias(AliasArgs),
 }
 
 /// History backend type
@@ -192,6 +194,7 @@ impl CliApp {
             Commands::Tokens(args) => handle_tokens(self, args),
             Commands::Hosts(args) => handle_hosts(self, args),
             Commands::Sessions(args) => handle_sessions(self, args),
+            Commands::Alias(args) => handle_alias(self, args),
         }
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -53,6 +53,16 @@ pub struct Token {
     pub created_at: DateTime<Utc>,
 }
 
+/// Represents a shell alias
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Alias {
+    pub alias: String,
+    pub command: String,
+    pub description: String,
+    pub date_created: DateTime<Utc>,
+    pub date_updated: DateTime<Utc>,
+}
+
 /// Statistics about the database
 #[derive(Debug, Clone, Default)]
 pub struct DatabaseStats {
@@ -147,6 +157,18 @@ impl Database {
                 original_value TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 FOREIGN KEY (command_id) REFERENCES commands(id) ON DELETE CASCADE
+            )",
+            [],
+        )?;
+
+        // Aliases table
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS aliases (
+                alias TEXT PRIMARY KEY,
+                command TEXT NOT NULL,
+                description TEXT NOT NULL,
+                date_created TEXT NOT NULL,
+                date_updated TEXT NOT NULL
             )",
             [],
         )?;
@@ -737,6 +759,95 @@ impl Database {
         Ok(imported_count)
     }
 
+    /// Add a new alias
+    pub fn add_alias(&self, alias: &str, command: &str, description: &str) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO aliases (alias, command, description, date_created, date_updated)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![alias, command, description, now, now],
+        )?;
+        Ok(())
+    }
+
+    /// Update an existing alias
+    pub fn update_alias(
+        &self,
+        alias: &str,
+        command: &str,
+        description: Option<&str>,
+    ) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        if let Some(desc) = description {
+            self.conn.execute(
+                "UPDATE aliases SET command = ?1, description = ?2, date_updated = ?3
+                 WHERE alias = ?4",
+                params![command, desc, now, alias],
+            )?;
+        } else {
+            self.conn.execute(
+                "UPDATE aliases SET command = ?1, date_updated = ?2 WHERE alias = ?3",
+                params![command, now, alias],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Remove an alias
+    pub fn remove_alias(&self, alias: &str) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM aliases WHERE alias = ?1", params![alias])?;
+        Ok(())
+    }
+
+    /// List all aliases ordered by name
+    #[must_use = "Alias list should be used"]
+    pub fn list_aliases(&self) -> Result<Vec<Alias>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT alias, command, description, date_created, date_updated
+             FROM aliases ORDER BY alias ASC",
+        )?;
+
+        let aliases = stmt
+            .query_map([], |row| {
+                Ok(Alias {
+                    alias: row.get(0)?,
+                    command: row.get(1)?,
+                    description: row.get(2)?,
+                    date_created: row
+                        .get::<_, String>(3)?
+                        .parse()
+                        .unwrap_or_else(|_| Utc::now()),
+                    date_updated: row
+                        .get::<_, String>(4)?
+                        .parse()
+                        .unwrap_or_else(|_| Utc::now()),
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(aliases)
+    }
+
+    /// Upsert aliases from shell environment (sync)
+    /// Returns the number of aliases upserted
+    pub fn sync_aliases(&self, aliases: &[(String, String)]) -> Result<usize> {
+        let now = Utc::now().to_rfc3339();
+        let mut count = 0;
+
+        for (name, command) in aliases {
+            self.conn.execute(
+                "INSERT INTO aliases (alias, command, description, date_created, date_updated)
+                 VALUES (?1, ?2, '', ?3, ?4)
+                 ON CONFLICT(alias) DO UPDATE SET command = ?2, date_updated = ?4",
+                params![name, command, now, now],
+            )?;
+            count += 1;
+        }
+
+        Ok(count)
+    }
+
     /// Clear all data (for testing)
     pub fn clear(&self) -> Result<()> {
         self.conn.execute("DELETE FROM tokens", [])?;
@@ -795,6 +906,55 @@ mod tests {
         let tokens = db.get_tokens_for_command(CommandId::new(cmd_id)).unwrap();
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].original_value, "password123");
+    }
+
+    #[test]
+    fn test_alias_crud() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db = Database::new(temp_file.path()).unwrap();
+
+        // Add
+        db.add_alias("ll", "ls -la", "long listing").unwrap();
+        let aliases = db.list_aliases().unwrap();
+        assert_eq!(aliases.len(), 1);
+        assert_eq!(aliases[0].alias, "ll");
+        assert_eq!(aliases[0].command, "ls -la");
+        assert_eq!(aliases[0].description, "long listing");
+
+        // Update
+        db.update_alias("ll", "ls -lah", Some("long listing with human sizes"))
+            .unwrap();
+        let aliases = db.list_aliases().unwrap();
+        assert_eq!(aliases[0].command, "ls -lah");
+        assert_eq!(aliases[0].description, "long listing with human sizes");
+
+        // Remove
+        db.remove_alias("ll").unwrap();
+        let aliases = db.list_aliases().unwrap();
+        assert!(aliases.is_empty());
+    }
+
+    #[test]
+    fn test_alias_sync() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db = Database::new(temp_file.path()).unwrap();
+
+        let aliases = vec![
+            ("ll".to_string(), "ls -la".to_string()),
+            ("gs".to_string(), "git status".to_string()),
+        ];
+
+        let count = db.sync_aliases(&aliases).unwrap();
+        assert_eq!(count, 2);
+
+        // Sync again with updated command — should upsert
+        let updated = vec![("ll".to_string(), "ls -lah".to_string())];
+        db.sync_aliases(&updated).unwrap();
+
+        let all = db.list_aliases().unwrap();
+        assert_eq!(all.len(), 2);
+        let ll = all.iter().find(|a| a.alias == "ll").unwrap();
+        assert_eq!(ll.command, "ls -lah");
     }
 
     #[test]

--- a/src/history_db.rs
+++ b/src/history_db.rs
@@ -19,7 +19,7 @@ use tracing::{debug, info};
 /// Database-backed history manager
 pub struct HistoryManagerDb {
     config: Config,
-    db: Database,
+    pub(crate) db: Database,
     redaction_engine: RedactionEngine,
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -555,6 +555,7 @@ mod tests {
                 directory: "/home/user".to_string(),
                 redacted: false,
                 original: None,
+                deleted: false,
             },
             HistoryEntry {
                 command: "ls -la".to_string(),
@@ -562,6 +563,7 @@ mod tests {
                 directory: "/home/user/documents".to_string(),
                 redacted: false,
                 original: None,
+                deleted: false,
             },
             HistoryEntry {
                 command: "password=<redacted>".to_string(),
@@ -569,6 +571,7 @@ mod tests {
                 directory: "/home/user".to_string(),
                 redacted: true,
                 original: Some("password=secret123".to_string()),
+                deleted: false,
             },
             HistoryEntry {
                 command: "echo Hello World".to_string(),
@@ -576,6 +579,7 @@ mod tests {
                 directory: "/tmp".to_string(),
                 redacted: false,
                 original: None,
+                deleted: false,
             },
         ]
     }
@@ -656,6 +660,7 @@ mod tests {
             directory: "/home/user".to_string(),
             redacted: false,
             original: None,
+            deleted: false,
         });
 
         let frequent = engine.get_frequent_commands(&entries).unwrap();
@@ -695,6 +700,7 @@ mod tests {
                 directory: "/home/user".to_string(),
                 redacted: false,
                 original: None,
+                deleted: false,
             },
             HistoryEntry {
                 command: "some echo command".to_string(), // Should score lower
@@ -702,6 +708,7 @@ mod tests {
                 directory: "/home/user".to_string(),
                 redacted: false,
                 original: None,
+                deleted: false,
             },
         ];
 


### PR DESCRIPTION
## Summary
- Integrates shell alias management into mortimer, absorbing the standalone [zam](https://github.com/fmeyer/zam) project
- Aliases stored in SQLite (`aliases` table) with full CRUD, upsert sync, and shell script export
- Shell integration auto-syncs current aliases on startup (`alias | mortimer alias sync &`)

## New commands
```
mortimer alias add <name> <command> <description>
mortimer alias update <name> <command> [--description <desc>]
mortimer alias remove <name>
mortimer alias list                # table format
mortimer alias list --shell        # eval-ready: alias name='cmd'
mortimer alias export [-O file.sh] # shell script (stdout default)
mortimer alias sync                # upsert from stdin (piped alias output)
```

## Test plan
- [x] `cargo check` compiles cleanly
- [x] `cargo test` — 65 tests pass (2 new alias tests)
- [x] `cargo clippy` — no new warnings
- [ ] Manual: `mortimer alias add ll "ls -la" "long listing"` then `mortimer alias list`
- [ ] Manual: `alias | mortimer alias sync` reads current shell aliases
- [ ] Manual: `mortimer shell zsh` includes auto-sync hook