### PR TITLE
feat: Make database the default backend

### DIFF
--- a/src/cli/handlers/alias.rs
+++ b/src/cli/handlers/alias.rs
@@ -10,7 +10,7 @@ pub fn handle_alias(app: &mut CliApp, args: &AliasArgs) -> Result<()> {
         HistoryBackend::Database(mgr) => &mgr.db,
         HistoryBackend::File(_) => {
             return Err(Error::custom(
-                "Alias management requires the database backend. Use --use-db flag.",
+                "Alias management requires the database backend. Remove --use-file flag to use the default database backend.",
             ));
         }
     };

--- a/src/cli/handlers/config.rs
+++ b/src/cli/handlers/config.rs
@@ -113,7 +113,7 @@ pub fn handle_status(app: &mut CliApp) -> Result<()> {
                     "Note: A database file exists at {}",
                     app.config.history_file.with_extension("db").display()
                 );
-                println!("   To use it, run commands with --use-db flag\n");
+                println!("   Remove --use-file flag to use the default database backend\n");
             }
         }
         HistoryBackend::Database(_) => {
@@ -132,9 +132,9 @@ pub fn handle_status(app: &mut CliApp) -> Result<()> {
     }
 
     // Show environment variables
-    if std::env::var("MORTIMER_USE_DB").is_ok() {
+    if std::env::var("MORTIMER_USE_FILE").is_ok() {
         println!("Environment:");
-        println!("  MORTIMER_USE_DB: set (forcing database backend)\n");
+        println!("  MORTIMER_USE_FILE: set (forcing file-based backend)\n");
     }
 
     // Show configuration

--- a/src/cli/handlers/database.rs
+++ b/src/cli/handlers/database.rs
@@ -9,7 +9,7 @@ pub fn handle_merge(app: &mut CliApp, args: &MergeArgs) -> Result<()> {
         HistoryBackend::Database(mgr) => mgr,
         HistoryBackend::File(_) => {
             return Err(Error::custom(
-                "Merge requires database backend. Use --use-db flag.",
+                "Merge requires database backend. Remove --use-file flag to use the default database backend.",
             ));
         }
     };
@@ -37,7 +37,7 @@ pub fn handle_tokens(app: &mut CliApp, args: &TokensArgs) -> Result<()> {
         HistoryBackend::Database(mgr) => mgr,
         HistoryBackend::File(_) => {
             return Err(Error::custom(
-                "Token management requires database backend. Use --use-db flag.",
+                "Token management requires database backend. Remove --use-file flag to use the default database backend.",
             ));
         }
     };
@@ -88,7 +88,7 @@ pub fn handle_hosts(app: &mut CliApp, args: &HostsArgs) -> Result<()> {
         HistoryBackend::Database(mgr) => mgr,
         HistoryBackend::File(_) => {
             return Err(Error::custom(
-                "Host management requires database backend. Use --use-db flag.",
+                "Host management requires database backend. Remove --use-file flag to use the default database backend.",
             ));
         }
     };
@@ -128,7 +128,7 @@ pub fn handle_sessions(app: &mut CliApp, args: &SessionsArgs) -> Result<()> {
         HistoryBackend::Database(mgr) => mgr,
         HistoryBackend::File(_) => {
             return Err(Error::custom(
-                "Session management requires database backend. Use --use-db flag.",
+                "Session management requires database backend. Remove --use-file flag to use the default database backend.",
             ));
         }
     };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -42,11 +42,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_color: bool,
 
-    /// Use database backend instead of file-based (default: auto-detect)
-    #[arg(long, global = true)]
-    pub use_db: bool,
-
-    /// Force file-based backend
+    /// Force file-based backend instead of default database backend
     #[arg(long, global = true)]
     pub use_file: bool,
 
@@ -124,20 +120,13 @@ impl CliApp {
         };
 
         // Determine which backend to use
+        // Database is the default; file-based is only used when explicitly requested
         let backend = if cli.use_file {
             // Explicitly use file backend
             HistoryBackend::File(HistoryManager::new(config.clone())?)
-        } else if cli.use_db || std::env::var("MORTIMER_USE_DB").is_ok() {
-            // Explicitly use database backend (via flag or env var)
-            HistoryBackend::Database(HistoryManagerDb::new(config.clone())?)
         } else {
-            // Auto-detect: use database if .db file exists, otherwise use file
-            let db_path = config.history_file.with_extension("db");
-            if db_path.exists() {
-                HistoryBackend::Database(HistoryManagerDb::new(config.clone())?)
-            } else {
-                HistoryBackend::File(HistoryManager::new(config.clone())?)
-            }
+            // Default to database backend
+            HistoryBackend::Database(HistoryManagerDb::new(config.clone())?)
         };
 
         // Initialize search engine

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,10 @@ pub const DEFAULT_HISTORY_FILE: &str = "mortimer.log";
 
 /// Get the default history file path
 ///
-/// Returns `<data_local_dir>/log/mortimer/mortimer.log`:
-/// - Linux: `~/.local/share/log/mortimer/mortimer.log`
-/// - macOS: `~/Library/Application Support/log/mortimer/mortimer.log`
+/// Returns `~/.local/mortimer/mortimer.log`
 pub fn default_history_path() -> Result<PathBuf> {
-    let data_dir = dirs::data_local_dir().ok_or(Error::HomeDirectoryNotFound)?;
-    Ok(data_dir.join("log").join("mortimer").join(DEFAULT_HISTORY_FILE))
+    let home = dirs::home_dir().ok_or(Error::HomeDirectoryNotFound)?;
+    Ok(home.join(".local").join("mortimer").join(DEFAULT_HISTORY_FILE))
 }
 
 /// Initialize the library with default configuration


### PR DESCRIPTION
## Summary
- Database is now the default backend — no need for `--use-db` flag or `MORTIMER_USE_DB` env var
- Removed `--use-db` CLI flag entirely; `--use-file` remains for explicitly opting into file-only mode
- Updated default storage path from `~/Library/Application Support/log/mortimer/` to `~/.local/mortimer/`
- Updated all error messages referencing the removed flag

## Test plan
- [x] `cargo test` — 63 tests passing
- [x] `cargo clippy` — zero warnings
- [ ] Verify `mortimer alias list` works without `--use-db`
- [ ] Verify `mortimer --use-file alias list` returns appropriate error